### PR TITLE
Refactor skills

### DIFF
--- a/app/src/main/java/com/example/tanuls2/db/AppDatabase.kt
+++ b/app/src/main/java/com/example/tanuls2/db/AppDatabase.kt
@@ -7,7 +7,7 @@ import com.example.tanuls2.db.converter.DataConverter
 import com.example.tanuls2.db.dao.KnightDao
 import com.example.tanuls2.db.entity.KnightEntity
 
-@Database(entities = [KnightEntity::class], version = 1)
+@Database(entities = [KnightEntity::class], version = 2)
 @TypeConverters(DataConverter::class)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun knightDao(): KnightDao

--- a/app/src/main/java/com/example/tanuls2/db/converter/DataConverter.kt
+++ b/app/src/main/java/com/example/tanuls2/db/converter/DataConverter.kt
@@ -2,6 +2,7 @@ package com.example.tanuls2.db.converter
 
 import androidx.room.TypeConverter
 import com.example.tanuls2.model.Item
+import com.example.tanuls2.model.Skill
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 
@@ -15,6 +16,16 @@ class DataConverter {
     @TypeConverter
     fun itemListFromJson(value: String) : ArrayList<Item> {
         return Gson().fromJson(value, object: TypeToken<ArrayList<Item>>(){}.type)
+    }
+
+    @TypeConverter
+    fun skillListToJson(value: ArrayList<Skill>) : String {
+        return Gson().toJson(value, object: TypeToken<ArrayList<Skill>>(){}.type)
+    }
+
+    @TypeConverter
+    fun skillListFromJson(value: String) : ArrayList<Skill> {
+        return Gson().fromJson(value, object: TypeToken<ArrayList<Skill>>(){}.type)
     }
 
 }

--- a/app/src/main/java/com/example/tanuls2/db/entity/KnightEntity.kt
+++ b/app/src/main/java/com/example/tanuls2/db/entity/KnightEntity.kt
@@ -4,6 +4,7 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.example.tanuls2.model.Item
+import com.example.tanuls2.model.Skill
 
 @Entity(tableName = "knight_table")
 data class KnightEntity(
@@ -15,5 +16,6 @@ data class KnightEntity(
     @ColumnInfo(name = "damage") val damage:Int,
     @ColumnInfo(name ="criticalHitChance") val criticalHitChance:Float,
     @ColumnInfo(name = "blockChance") val blockChance:Float,
-    @ColumnInfo(name= "items") val itemList: ArrayList<Item> = arrayListOf())
+    @ColumnInfo(name= "items") val itemList: ArrayList<Item> = arrayListOf(),
+    @ColumnInfo(name= "skills") val skillList: ArrayList<Skill> = arrayListOf())
 

--- a/app/src/main/java/com/example/tanuls2/model/Knight.kt
+++ b/app/src/main/java/com/example/tanuls2/model/Knight.kt
@@ -8,5 +8,6 @@ data class Knight(val uid: Int,
                   var damage:Int,
                   var criticalHitChance:Float,
                   var blockChance:Float,
-                  var itemList: ArrayList<Item> = arrayListOf())
+                  var itemList: ArrayList<Item> = arrayListOf(),
+                  var skillList:ArrayList<Skill> = arrayListOf())
 

--- a/app/src/main/java/com/example/tanuls2/model/Skill.kt
+++ b/app/src/main/java/com/example/tanuls2/model/Skill.kt
@@ -1,11 +1,16 @@
 package com.example.tanuls2.model
 
-open class Skill(var skillName:String?,
-                 var level:Int,
-                 var health:Int,
-                 var damage:Int,
+open class Skill(var skillLabel: String?,
+                 var level: Int,
+                 var health: Int,
+                 var damage: Int,
                  var criticalHitChance: Float,
                  var blockChance: Float,
-                 var lifeSteal:Float,
-                 var equipped:Boolean)
+                 var lifeSteal: Float,
+                 var equipped: Boolean,
+                 var skillName: SkillName)
+
+enum class SkillName {
+    DOUBLE_HIT, CRITICAL_HIT, PRECISION_HIT, LIFE_STEAL_HIT, HEAL
+}
 

--- a/app/src/main/java/com/example/tanuls2/model/Skill.kt
+++ b/app/src/main/java/com/example/tanuls2/model/Skill.kt
@@ -1,0 +1,11 @@
+package com.example.tanuls2.model
+
+open class Skill(var skillName:String?,
+                 var level:Int,
+                 var health:Int,
+                 var damage:Int,
+                 var criticalHitChance: Float,
+                 var blockChance: Float,
+                 var lifeSteal:Float,
+                 var equipped:Boolean)
+

--- a/app/src/main/java/com/example/tanuls2/model/Zombie.kt
+++ b/app/src/main/java/com/example/tanuls2/model/Zombie.kt
@@ -9,10 +9,3 @@ data class Zombie(
     val criticalHitChance:Float = 0.2f,
     var blockChance:Float = 0.3f
 )
-//    :Character(0,
-//                        1000,
-//                        1000,
-//                        1,
-//                        10,
-//                        0.2f,
-//                        0.3f)

--- a/app/src/main/java/com/example/tanuls2/service/datasource/CombatLocalDataSource.kt
+++ b/app/src/main/java/com/example/tanuls2/service/datasource/CombatLocalDataSource.kt
@@ -10,16 +10,24 @@ import io.reactivex.rxjava3.schedulers.Schedulers
 
 class CombatLocalDataSource(val knightDao: KnightDao) {
 
-    var skillExtraDamage = Skill("Dupla ütés", 1,0,100,0f,0f,0f,true)
-    var skillPrecisionHit = Skill("Precíz ütés",1,0,0,0f,0.0f,0f,true)
-    var skillCriticalHit  = Skill ("Kritikus ütés",1,0,0,1.0f,0f,0f,true)
-    var skillLifeSteal  = Skill("Gyógyító ütés", 1,0,0,0f,0f,0.5f,true)
-    var skillHeal = Skill("Gyógyítás", 1,25,0,0f,0f,0f,false)
+    companion object {
+        const val DOUBLE_HIT = "Dupla ütés"
+        const val CRITICAL_HIT = "Kritikus ütés"
+        const val PRECISION_HIT  = "Precíz ütés"
+        const val LIFE_STEAL_HIT  = "Gyógyító ütés"
+        const val HEAL = "Gyógyítás"
+    }
+
+    var skillExtraDamage = Skill(DOUBLE_HIT, 1, 0, 100, 0f, 0f, 0f, true, SkillName.DOUBLE_HIT)
+    var skillPrecisionHit = Skill(PRECISION_HIT, 1, 0, 0, 0f, 0.0f, 0f, true, SkillName.PRECISION_HIT)
+    var skillCriticalHit  = Skill (CRITICAL_HIT, 1, 0, 0, 1.0f, 0f, 0f, true, SkillName.CRITICAL_HIT)
+    var skillLifeSteal  = Skill(LIFE_STEAL_HIT, 1, 0, 0, 0f, 0f, 0.5f, true, SkillName.LIFE_STEAL_HIT)
+    var skillHeal = Skill(HEAL, 1, 25, 0, 0f, 0f, 0f, false, SkillName.HEAL)
     
     fun fetchLocalKnightData() : Single<KnightEntity> {
         return Single.fromCallable {
             if(SharedPreferencesHandler.isFirstStart()){
-                var skillList = arrayListOf(skillExtraDamage,skillCriticalHit,skillPrecisionHit,skillLifeSteal,skillHeal)
+                var skillList = arrayListOf(skillExtraDamage, skillCriticalHit, skillPrecisionHit, skillLifeSteal, skillHeal)
 
                     var itemList = arrayListOf<Item>()
                 for (i in 0..11) {

--- a/app/src/main/java/com/example/tanuls2/service/datasource/CombatLocalDataSource.kt
+++ b/app/src/main/java/com/example/tanuls2/service/datasource/CombatLocalDataSource.kt
@@ -3,24 +3,29 @@ package com.example.tanuls2.service.datasource
 import com.example.tanuls2.db.dao.KnightDao
 import com.example.tanuls2.db.entity.KnightEntity
 import com.example.tanuls2.handler.SharedPreferencesHandler
-import com.example.tanuls2.model.EmptySlot
-import com.example.tanuls2.model.Item
-import com.example.tanuls2.model.Knight
-import com.example.tanuls2.model.Zombie
+import com.example.tanuls2.model.*
 import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.core.Single
 import io.reactivex.rxjava3.schedulers.Schedulers
 
 class CombatLocalDataSource(val knightDao: KnightDao) {
 
+    var skillExtraDamage = Skill("Dupla ütés", 1,0,100,0f,0f,0f,true)
+    var skillPrecisionHit = Skill("Precíz ütés",1,0,0,0f,0.0f,0f,true)
+    var skillCriticalHit  = Skill ("Kritikus ütés",1,0,0,1.0f,0f,0f,true)
+    var skillLifeSteal  = Skill("Gyógyító ütés", 1,0,0,0f,0f,0.5f,true)
+    var skillHeal = Skill("Gyógyítás", 1,25,0,0f,0f,0f,false)
+    
     fun fetchLocalKnightData() : Single<KnightEntity> {
         return Single.fromCallable {
             if(SharedPreferencesHandler.isFirstStart()){
-                var itemList = arrayListOf<Item>()
+                var skillList = arrayListOf(skillExtraDamage,skillCriticalHit,skillPrecisionHit,skillLifeSteal,skillHeal)
+
+                    var itemList = arrayListOf<Item>()
                 for (i in 0..11) {
                     itemList.add(EmptySlot())
                 }
-                knightDao.insertKnight(knightEntity = KnightEntity(0,0,100,100,1,100,0.2f,0.2f, itemList))
+                knightDao.insertKnight(knightEntity = KnightEntity(0,0,100,100,1,100,0.2f,0.2f, itemList, skillList))
                 SharedPreferencesHandler.setFirstStart(false)
             }
             knightDao.getKnight()
@@ -36,7 +41,9 @@ class CombatLocalDataSource(val knightDao: KnightDao) {
 
     fun saveKnightToDb(knight: Knight) : Completable {
         return Completable.fromCallable {
-            knightDao.insertKnight(KnightEntity(0, knight.experience, knight.currentHealth, knight.maxHealth, knight.level, knight.damage, knight.criticalHitChance, knight.blockChance, knight.itemList))
+            knightDao.insertKnight(KnightEntity(0, knight.experience, knight.currentHealth, knight.maxHealth, knight.level, knight.damage, knight.criticalHitChance, knight.blockChance, knight.itemList, knight.skillList))
         }.subscribeOn(Schedulers.io())
     }
+
+
 }

--- a/app/src/main/java/com/example/tanuls2/ui/view/CombatFragment.kt
+++ b/app/src/main/java/com/example/tanuls2/ui/view/CombatFragment.kt
@@ -317,38 +317,33 @@ class CombatFragment : Fragment() {
     }
 
     fun checkEquippedSkills(){
-        val skillListLength = combatViewModel.currentKnight!!.skillList.count()
         equippedSkillsList = arrayListOf()
-        for (i in 0..skillListLength-1) {
-            if(combatViewModel.currentKnight!!.skillList[i].equipped){
-                equippedSkillsList.add(combatViewModel.currentKnight!!.skillList[i])
-            }
-        }
+        equippedSkillsList = combatViewModel.currentKnight!!.skillList.filter { it.equipped } as ArrayList<Skill>
     }
 
     fun skillActivation(index : Int){
         checkEquippedSkills()
         clearZombieHitResults()
-        when(equippedSkillsList[index].skillName){
-            getString(R.string.skill_double_hit)->{
-             var extraDamageSkill = combatViewModel.currentKnight!!.skillList[index].damage
-             hitWithKnight(extraDamage = extraDamageSkill)
-         }
-            getString(R.string.skill_critical_hit)->{
+        when(equippedSkillsList[index].skillName) {
+            SkillName.DOUBLE_HIT -> {
+                var extraDamageSkill = combatViewModel.currentKnight!!.skillList[index].damage
+                 hitWithKnight(extraDamage = extraDamageSkill)
+            }
+            SkillName.CRITICAL_HIT -> {
                 val originalCriticalHitChance = combatViewModel.currentKnight!!.criticalHitChance
                 combatViewModel.currentKnight!!.criticalHitChance =
                     combatViewModel.currentKnight!!.skillList[index].criticalHitChance
                 hitWithKnight()
                 combatViewModel.currentKnight!!.criticalHitChance = originalCriticalHitChance
             }
-            getString(R.string.skill_precision_hit)->{
+            SkillName.PRECISION_HIT -> {
                 val originalBlockChance = zombie.blockChance
                 zombie.blockChance =
                     combatViewModel.currentKnight!!.skillList[index].blockChance
                 hitWithKnight()
                 zombie.blockChance = originalBlockChance
             }
-            getString(R.string.skill_life_steal_hit)->{
+            SkillName.LIFE_STEAL_HIT -> {
                 val actualHealthOfEnemy = zombie.currentHealth
                 hitWithKnight()
                 val damage = (actualHealthOfEnemy - zombie.currentHealth)*
@@ -365,6 +360,7 @@ class CombatFragment : Fragment() {
                     }
                 }
             }
+            SkillName.HEAL -> {}
 
         }
         printKnightParameter(combatViewModel.currentKnight!!)

--- a/app/src/main/java/com/example/tanuls2/ui/view/CombatFragment.kt
+++ b/app/src/main/java/com/example/tanuls2/ui/view/CombatFragment.kt
@@ -23,6 +23,7 @@ class CombatFragment : Fragment() {
     lateinit var zombie: Zombie
     var defeatAlertdialog: AlertDialog? = null
     var victoryAlertdialog: AlertDialog? = null
+    var equippedSkillsList : ArrayList<Skill> = arrayListOf()
 
     val combatViewModel: CombatViewModel by viewModel()
 
@@ -60,19 +61,23 @@ class CombatFragment : Fragment() {
         }
 
         knightSkill1Id.setOnClickListener {
-            skillExtraDamage()
+            skillActivation(0)
+            skillDisable(knightSkill1Id)
         }
 
         knightSkill2Id.setOnClickListener {
-            skillExtraCriticalHitChance()
+            skillActivation(1)
+            skillDisable(knightSkill2Id)
         }
 
         knightSkill3Id.setOnClickListener {
-            skillEliminateBlockChance()
+            skillActivation(2)
+            skillDisable(knightSkill3Id)
         }
 
         knightSkill4Id.setOnClickListener {
-            skillBloodSiphon()
+            skillActivation(3)
+            skillDisable(knightSkill4Id)
         }
     }
 
@@ -311,51 +316,57 @@ class CombatFragment : Fragment() {
         appCompatImageView.alpha = 0.4f
     }
 
-    fun skillExtraDamage() {
-        clearZombieHitResults()
-        hitWithKnight(extraDamage = 100)
-        skillDisable(knightSkill1Id)
-        printKnightParameter(combatViewModel.currentKnight!!)
-        printZombieParameter(zombie)
-    }
-
-    fun skillExtraCriticalHitChance() {
-        clearZombieHitResults()
-        val originalCriticalHitChance = combatViewModel.currentKnight!!.criticalHitChance
-        combatViewModel.currentKnight!!.criticalHitChance += (1.0f - originalCriticalHitChance)
-        hitWithKnight()
-        combatViewModel.currentKnight!!.criticalHitChance = originalCriticalHitChance
-        skillDisable(knightSkill2Id)
-        printKnightParameter(combatViewModel.currentKnight!!)
-        printZombieParameter(zombie)
-    }
-
-    fun skillEliminateBlockChance() {
-        clearZombieHitResults()
-        val originalBlockChance = zombie.blockChance
-        zombie.blockChance = 0.0f
-        hitWithKnight()
-        zombie.blockChance = originalBlockChance
-        skillDisable(knightSkill3Id)
-        printKnightParameter(combatViewModel.currentKnight!!)
-        printZombieParameter(zombie)
-    }
-
-    fun skillBloodSiphon() {
-        clearZombieHitResults()
-        val actualHealthOfEnemy = zombie.currentHealth
-        hitWithKnight()
-        val modifiedHealth =
-            combatViewModel.currentKnight!!.currentHealth + (actualHealthOfEnemy - zombie.currentHealth)
-        combatViewModel.currentKnight!!.currentHealth = when (modifiedHealth >= combatViewModel.currentKnight!!.maxHealth) {
-            true -> {
-                combatViewModel.currentKnight!!.maxHealth
-            }
-            else -> {
-                modifiedHealth
+    fun checkEquippedSkills(){
+        val skillListLength = combatViewModel.currentKnight!!.skillList.count()
+        equippedSkillsList = arrayListOf()
+        for (i in 0..skillListLength-1) {
+            if(combatViewModel.currentKnight!!.skillList[i].equipped){
+                equippedSkillsList.add(combatViewModel.currentKnight!!.skillList[i])
             }
         }
-        skillDisable(knightSkill4Id)
+    }
+
+    fun skillActivation(index : Int){
+        checkEquippedSkills()
+        clearZombieHitResults()
+        when(equippedSkillsList[index].skillName){
+            getString(R.string.skill_double_hit)->{
+             var extraDamageSkill = combatViewModel.currentKnight!!.skillList[index].damage
+             hitWithKnight(extraDamage = extraDamageSkill)
+         }
+            getString(R.string.skill_critical_hit)->{
+                val originalCriticalHitChance = combatViewModel.currentKnight!!.criticalHitChance
+                combatViewModel.currentKnight!!.criticalHitChance =
+                    combatViewModel.currentKnight!!.skillList[index].criticalHitChance
+                hitWithKnight()
+                combatViewModel.currentKnight!!.criticalHitChance = originalCriticalHitChance
+            }
+            getString(R.string.skill_precision_hit)->{
+                val originalBlockChance = zombie.blockChance
+                zombie.blockChance =
+                    combatViewModel.currentKnight!!.skillList[index].blockChance
+                hitWithKnight()
+                zombie.blockChance = originalBlockChance
+            }
+            getString(R.string.skill_life_steal_hit)->{
+                val actualHealthOfEnemy = zombie.currentHealth
+                hitWithKnight()
+                val damage = (actualHealthOfEnemy - zombie.currentHealth)*
+                        combatViewModel.currentKnight!!.skillList[index].lifeSteal
+                val modifiedHealth =
+                    combatViewModel.currentKnight!!.currentHealth +damage
+                combatViewModel.currentKnight!!.currentHealth =
+                    when (modifiedHealth >= combatViewModel.currentKnight!!.maxHealth) {
+                    true -> {
+                        combatViewModel.currentKnight!!.maxHealth
+                    }
+                    else -> {
+                        modifiedHealth.toInt()
+                    }
+                }
+            }
+
+        }
         printKnightParameter(combatViewModel.currentKnight!!)
         printZombieParameter(zombie)
     }

--- a/app/src/main/java/com/example/tanuls2/ui/viewmodel/CombatViewModel.kt
+++ b/app/src/main/java/com/example/tanuls2/ui/viewmodel/CombatViewModel.kt
@@ -43,7 +43,7 @@ class CombatViewModel(
                     knightEntityData.currentHealth, knightEntityData.maxHealth,
                     knightEntityData.level, knightEntityData.damage,
                     knightEntityData.criticalHitChance, knightEntityData.blockChance,
-                    knightEntityData.itemList), zombieData)
+                    knightEntityData.itemList, knightEntityData.skillList), zombieData)
             }
             .subscribeOn(AndroidSchedulers.mainThread())
             .observeOn(Schedulers.io())

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,12 @@
     <string name="knight_skill3">Precíz ütés</string>
     <string name="knight_skill4">Gyógyító ütés</string>
 
+    <string name="skill_double_hit">Dupla ütés</string>
+    <string name="skill_critical_hit">Kritikus ütés</string>
+    <string name="skill_precision_hit">Precíz ütés</string>
+    <string name="skill_life_steal_hit">Gyógyító ütés</string>
+
+
     <string name="knight_name_label">Lovag</string>
     <string name="enemy_name_label">Zombi</string>
     <string name="level_label">Szint</string>


### PR DESCRIPTION
### Refactor skills

-AppDatabase version change 1 to 2
-Create typeConverter to skillList
-Add skills columnInfo to KnightEntity
-Add skillList to Knight
-Create skills in CombatLocalDataSource
-Add skills to skillList in CombatLocalDataSource
-Add skillList to KnightDao.insertKnight in CombatLocalDataSource
-Create skillActivation function and checkEquippedSkills function, remove old skill functions on CombatFragment
-Use skillActivation function on knightSkills setOnClickListeners
-Add skillList to knightEntityData on CombatViewModel
-Create Skill class

### Plan

-Show the equipped skills icons and names on the CombatFragment
-Create RecyclerView layout for skills 
-Users can equip or unequip the skills on the skills fragment. Max. 4 skills can be equipped.